### PR TITLE
fix(lint): resolve clippy warnings from rust 1.95

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -264,7 +264,7 @@ fn write_file_types_table<W: Write>(
     writeln!(writer, "{}", "-".repeat(20))?;
 
     let mut type_data: Vec<_> = stats.file_types.iter().collect();
-    type_data.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+    type_data.sort_by_key(|b| std::cmp::Reverse(b.1.count));
 
     let type_rows: Vec<FileTypeRow> = type_data
         .into_iter()

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -226,10 +226,10 @@ pub fn sort_entries(entries: &mut [FileEntry], sort_by: crate::types::SortBy) {
             entries.sort_by(|a, b| a.path.cmp(&b.path));
         }
         SortBy::Size => {
-            entries.sort_by(|a, b| b.size.cmp(&a.size)); // Largest first
+            entries.sort_by_key(|b| std::cmp::Reverse(b.size)); // Largest first
         }
         SortBy::Modified => {
-            entries.sort_by(|a, b| b.modified.cmp(&a.modified)); // Newest first
+            entries.sort_by_key(|b| std::cmp::Reverse(b.modified)); // Newest first
         }
         SortBy::Type => {
             entries.sort_by(|a, b| match (&a.file_type, &b.file_type) {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -64,8 +64,8 @@ pub fn calculate_stats(entries: &[FileEntry]) -> FileStats {
     }
 
     // Calculate derived statistics
-    if stats.total_files > 0 {
-        stats.avg_file_size = stats.total_size / stats.total_files;
+    if let Some(avg) = stats.total_size.checked_div(stats.total_files) {
+        stats.avg_file_size = avg;
 
         if !file_sizes.is_empty() {
             stats.max_file_size = *file_sizes.iter().max().unwrap();
@@ -75,8 +75,8 @@ pub fn calculate_stats(entries: &[FileEntry]) -> FileStats {
 
     // Calculate average sizes for each file type
     for type_stats in stats.file_types.values_mut() {
-        if type_stats.count > 0 {
-            type_stats.avg_size = type_stats.total_size / type_stats.count;
+        if let Some(avg) = type_stats.total_size.checked_div(type_stats.count) {
+            type_stats.avg_size = avg;
         }
     }
 
@@ -98,7 +98,7 @@ pub fn calculate_stats(entries: &[FileEntry]) -> FileStats {
 /// A vector of the N largest files, sorted by size (largest first)
 pub fn get_largest_files(entries: &[FileEntry], n: usize) -> Vec<&FileEntry> {
     let mut files: Vec<&FileEntry> = entries.iter().filter(|e| !e.is_dir).collect();
-    files.sort_by(|a, b| b.size.cmp(&a.size));
+    files.sort_by_key(|b| std::cmp::Reverse(b.size));
     files.into_iter().take(n).collect()
 }
 
@@ -114,7 +114,7 @@ pub fn get_largest_files(entries: &[FileEntry], n: usize) -> Vec<&FileEntry> {
 /// A vector of tuples containing (file_type, TypeStats) sorted by count
 pub fn get_top_file_types(stats: &FileStats, n: usize) -> Vec<(&String, &TypeStats)> {
     let mut types: Vec<(&String, &TypeStats)> = stats.file_types.iter().collect();
-    types.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+    types.sort_by_key(|b| std::cmp::Reverse(b.1.count));
     types.into_iter().take(n).collect()
 }
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes CI failures on `cargo clippy --all-targets --all-features -- -D warnings`
caused by new lints introduced in Rust 1.95. Dependabot PRs were failing the
clippy job because of these warnings, blocking dependency updates from merging.

Two lint categories were addressed:

- **`clippy::unnecessary_sort_by`** — replaced `sort_by(|a, b| b.x.cmp(&a.x))`
  reverse comparators with `sort_by_key(|b| std::cmp::Reverse(b.x))` in:
  - `src/formatter.rs` (file-type table sort)
  - `src/scanner.rs` (size and modified-time sorts)
  - `src/stats.rs` (`get_largest_files`, `get_top_file_types`)
- **`clippy::manual_checked_ops`** — replaced manual `if x > 0 { a / x }`
  guards with `checked_div` in `src/stats.rs::calculate_stats` for both the
  overall average file size and per-type average size.

No behavioral change: `Reverse`-keyed sorts produce the same ordering as the
prior reverse comparators, and `checked_div` returns `None` exactly when the
divisor is zero, matching the previous guard.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

Verified locally:
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.

## Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated examples if applicable
- [ ] I have updated the CLI help text if applicable

N/A — internal lint cleanup only.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Related Issues
Unblocks pending Dependabot PRs failing on clippy in CI.

## Additional Notes
None.